### PR TITLE
feat: Support web URLs in --pdf and auto-extract title via LLM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,5 +82,6 @@ uv run pytest -m "integration or not integration"  # all tests
 2. **After code changes**: `uv run ruff format .` → `uv run ruff check .` → `uv run pyright` → `uv run pytest -m "not integration"` (order matters: format may change code that later tools re-check)
 3. **Doc check**: explicitly verify if docs/prompts need updating (even if "no doc impact")
 4. **CLI changes**: update `README.md`, `AGENT_INTEGRATION.md`, `skill/SKILL.md`, `skill/commands.md`
+5. **Doc style**: don't document default behavior (it's default); keep agent-facing docs KISS and concise
 
 If `uv run` fails (sandbox/offline): fall back to `.venv/bin/*` or set `UV_CACHE_DIR=$PWD/.uv-cache` and `UV_LINK_MODE=copy`.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pip install -e ".[all]"
 | Command | Purpose |
 |---------|---------|
 | `papi add <arxiv-id-or-url>` | Add a paper (downloads PDF + LaTeX, generates summary/equations/TL;DR) |
-| `papi add --pdf file.pdf --title "..."` | Add a local PDF |
+| `papi add --pdf file.pdf` | Add a local PDF or URL |
 | `papi add --from-file list.json` | Import papers from a JSON list or text file |
 | `papi list` | List papers (filter with `--tag`) |
 | `papi search "query"` | Search across titles, tags, summaries, equations (`--rg` for grep-style, default uses ranked BM25 if indexed) |
@@ -665,7 +665,8 @@ papi list --tag attention
 ## Non-arXiv papers
 
 ```bash
-papi add --pdf ./paper.pdf --title "Some Conference Paper" --tags local
+papi add --pdf ./paper.pdf
+papi add --pdf "https://example.com/paper.pdf" --tags siggraph
 ```
 
 ## Configuration file

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -52,7 +52,8 @@ papi ask "question" --backend leann   # LEANN RAG
 ```bash
 papi add 2303.13476                   # arXiv ID
 papi add https://arxiv.org/abs/...    # URL
-papi add --pdf /path/to.pdf --title "Title"  # local PDF
+papi add --pdf /path/to.pdf           # local PDF
+papi add --pdf "https://..."          # PDF from URL
 papi add --from-file papers.bib       # bulk import
 ```
 

--- a/skill/commands.md
+++ b/skill/commands.md
@@ -20,7 +20,7 @@
 | Command | Description |
 |---------|-------------|
 | `papi add <arxiv-id-or-url>` | Add paper (idempotent) |
-| `papi add --pdf PATH --title TEXT` | Add local PDF |
+| `papi add --pdf PATH_OR_URL` | Add local PDF or URL |
 | `papi add --from-file <file>` | Import from JSON/BibTeX/text |
 | `papi add <id> --update` | Refresh existing paper |
 | `papi add <id> --figures` | Extract figures from LaTeX/PDF |


### PR DESCRIPTION
## Summary
- `--pdf` now accepts HTTP/HTTPS URLs (downloads to temp file, then ingests)
- `--title` optional in LLM mode (extracts from PDF first page via PyMuPDF + LLM)
- `--title` still required with `--no-llm`

Closes #21

## Test plan
- [x] URL download: success, 404, timeout, connection error
- [x] Local file path still works
- [x] Title extraction with mocked LLM
- [x] `--no-llm` requires `--title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)