### PR TITLE
feat(cli): fuzzy matching for paper names

### DIFF
--- a/paperpipe/__init__.py
+++ b/paperpipe/__init__.py
@@ -7,6 +7,7 @@ from .config import *  # noqa: F403
 from .core import *  # noqa: F403
 from .install import *  # noqa: F403
 from .leann import *  # noqa: F403
+from .matching import *  # noqa: F403
 from .output import *  # noqa: F403
 from .paper import *  # noqa: F403
 from .paperqa import *  # noqa: F403

--- a/paperpipe/matching.py
+++ b/paperpipe/matching.py
@@ -1,0 +1,146 @@
+"""Paper name matching utilities."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from difflib import SequenceMatcher, get_close_matches
+from enum import Enum
+from typing import Optional
+
+import click
+
+
+class MatchType(Enum):
+    """Type of paper name match."""
+
+    EXACT = "exact"
+    NORMALIZED = "normalized"
+    FUZZY = "fuzzy"
+    NOT_FOUND = "not_found"
+
+
+@dataclass
+class MatchResult:
+    """Result of paper name matching."""
+
+    match_type: MatchType
+    matches: list[str]  # Empty for EXACT, 1+ for NORMALIZED/FUZZY
+    query: str  # Original query
+    normalized_query: str  # Normalized version
+
+
+def normalize_paper_name(name: str) -> str:
+    """Normalize paper name for fuzzy matching.
+
+    Strips hyphens, underscores, and lowercases.
+
+    Examples:
+        "IF-Net" -> "ifnet"
+        "my_paper" -> "mypaper"
+    """
+    raw = (name or "").strip()
+    return raw.replace("-", "").replace("_", "").lower()
+
+
+def find_paper_matches(
+    query: str,
+    index: dict,
+    *,
+    fuzzy_cutoff: float = 0.7,
+) -> MatchResult:
+    """Find paper name matches with exact, normalized, and fuzzy fallback.
+
+    Args:
+        query: User-provided paper name
+        index: Paper index dict {name: metadata}
+        fuzzy_cutoff: Minimum similarity for fuzzy matches (0.0-1.0)
+
+    Returns:
+        MatchResult with match type and candidate names
+    """
+    query_clean = query.strip()
+    if not query_clean:
+        return MatchResult(MatchType.NOT_FOUND, [], query, "")
+
+    # Exact match
+    if query_clean in index:
+        return MatchResult(MatchType.EXACT, [query_clean], query, query_clean)
+
+    # Build normalized -> list of original names (handles collisions)
+    query_norm = normalize_paper_name(query_clean)
+    index_normalized: dict[str, list[str]] = {}
+    for k in index.keys():
+        norm = normalize_paper_name(k)
+        index_normalized.setdefault(norm, []).append(k)
+
+    # Normalized match
+    if query_norm in index_normalized:
+        matches = index_normalized[query_norm]
+        if len(matches) == 1:
+            return MatchResult(MatchType.NORMALIZED, matches, query, query_norm)
+        # Multiple papers normalize identically - treat as ambiguous
+        return MatchResult(MatchType.FUZZY, matches, query, query_norm)
+
+    # Fuzzy match
+    candidates = list(index_normalized.keys())
+    fuzzy_matches = get_close_matches(query_norm, candidates, n=5, cutoff=fuzzy_cutoff)
+
+    if fuzzy_matches:
+        # Flatten: each fuzzy match may map to multiple original names
+        original_names = []
+        for m in fuzzy_matches:
+            original_names.extend(index_normalized[m])
+        return MatchResult(MatchType.FUZZY, original_names, query, query_norm)
+
+    return MatchResult(MatchType.NOT_FOUND, [], query, query_norm)
+
+
+def select_paper_interactively(
+    matches: list[str],
+    query: str,
+    index: dict,
+) -> Optional[str]:
+    """Prompt user to select from fuzzy matches.
+
+    Args:
+        matches: List of matching paper names (may be single low-confidence match)
+        query: Original query for context
+        index: Paper index for displaying titles
+
+    Returns:
+        Selected paper name or None if user cancels or non-interactive
+    """
+    if not matches:
+        return None
+
+    # Check if interactive - don't auto-select even single matches
+    # (caller handles high-confidence auto-selection separately)
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return None
+
+    click.secho(f"Multiple papers match '{query}':", fg="yellow")
+    for i, name in enumerate(matches, 1):
+        title = index.get(name, {}).get("title", "")
+        if title:
+            title_short = title[:50] + "..." if len(title) > 50 else title
+            click.echo(f"  {i}. {name} - {title_short}")
+        else:
+            click.echo(f"  {i}. {name}")
+    click.echo("  0. Cancel")
+
+    try:
+        choice = click.prompt("Select paper", type=int, default=0)
+        if 1 <= choice <= len(matches):
+            return matches[choice - 1]
+    except (click.Abort, KeyboardInterrupt):
+        pass
+
+    return None
+
+
+def get_best_fuzzy_similarity(query: str, match: str) -> float:
+    """Get similarity ratio between normalized query and match."""
+    query_norm = normalize_paper_name(query)
+    match_norm = normalize_paper_name(match)
+    return SequenceMatcher(None, query_norm, match_norm).ratio()

--- a/paperpipe/paper.py
+++ b/paperpipe/paper.py
@@ -538,9 +538,7 @@ def _generate_local_pdf_name(meta: dict, *, use_llm: bool, model: Optional[str] 
     return name or "paper"
 
 
-def generate_auto_name(
-    meta: dict, existing_names: set[str], use_llm: bool = True, model: Optional[str] = None
-) -> str:
+def generate_auto_name(meta: dict, existing_names: set[str], use_llm: bool = True, model: Optional[str] = None) -> str:
     """Generate a short memorable name for a paper.
 
     Strategy:
@@ -1026,9 +1024,7 @@ def _add_single_paper(
         if tldr:
             tldr_content = generate_simple_tldr(meta)
     else:
-        summary, equations, llm_tags, llm_tldr = generate_llm_content(
-            paper_dir, meta, tex_content, model=llm_model
-        )
+        summary, equations, llm_tags, llm_tldr = generate_llm_content(paper_dir, meta, tex_content, model=llm_model)
         if tldr:
             tldr_content = llm_tldr
 
@@ -1284,9 +1280,7 @@ def _update_existing_paper(
         if tldr:
             tldr_content = generate_simple_tldr(meta)
     else:
-        summary, equations, llm_tags, llm_tldr = generate_llm_content(
-            paper_dir, meta, tex_content, model=llm_model
-        )
+        summary, equations, llm_tags, llm_tldr = generate_llm_content(paper_dir, meta, tex_content, model=llm_model)
         if tldr:
             tldr_content = llm_tldr
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,201 @@
+"""Tests for paper name matching utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from paperpipe.matching import (
+    MatchResult,
+    MatchType,
+    find_paper_matches,
+    get_best_fuzzy_similarity,
+    normalize_paper_name,
+    select_paper_interactively,
+)
+
+
+class TestNormalizePaperName:
+    def test_strips_hyphens(self):
+        assert normalize_paper_name("if-net") == "ifnet"
+
+    def test_strips_underscores(self):
+        assert normalize_paper_name("my_paper") == "mypaper"
+
+    def test_lowercases(self):
+        assert normalize_paper_name("IF-Net") == "ifnet"
+
+    def test_combined(self):
+        assert normalize_paper_name("My_Super-Paper") == "mysuperpaper"
+
+    def test_empty_string(self):
+        assert normalize_paper_name("") == ""
+
+    def test_whitespace_stripped(self):
+        assert normalize_paper_name("  paper  ") == "paper"
+
+    def test_preserves_numbers(self):
+        assert normalize_paper_name("nerf-2020") == "nerf2020"
+
+
+class TestFindPaperMatches:
+    def test_exact_match(self):
+        index = {"nerf-2020": {}, "if-net": {}}
+        result = find_paper_matches("nerf-2020", index)
+        assert result.match_type == MatchType.EXACT
+        assert result.matches == ["nerf-2020"]
+
+    def test_normalized_match_hyphen(self):
+        index = {"if-net": {}, "nerf-2020": {}}
+        result = find_paper_matches("ifnet", index)
+        assert result.match_type == MatchType.NORMALIZED
+        assert result.matches == ["if-net"]
+
+    def test_normalized_match_underscore(self):
+        index = {"my_paper": {}, "other": {}}
+        result = find_paper_matches("mypaper", index)
+        assert result.match_type == MatchType.NORMALIZED
+        assert result.matches == ["my_paper"]
+
+    def test_normalized_match_case_insensitive(self):
+        index = {"NeRF": {}, "other": {}}
+        result = find_paper_matches("nerf", index)
+        assert result.match_type == MatchType.NORMALIZED
+        assert result.matches == ["NeRF"]
+
+    def test_fuzzy_match_typo(self):
+        index = {"neural-radiance-fields": {}, "other-paper": {}}
+        result = find_paper_matches("nueral-radiance-fields", index, fuzzy_cutoff=0.7)
+        assert result.match_type == MatchType.FUZZY
+        assert "neural-radiance-fields" in result.matches
+
+    def test_fuzzy_match_multiple(self):
+        index = {"nerf-2020": {}, "nerf-2021": {}, "nerf-w": {}}
+        result = find_paper_matches("nerf", index, fuzzy_cutoff=0.5)
+        assert result.match_type == MatchType.FUZZY
+        assert len(result.matches) >= 2
+
+    def test_not_found(self):
+        index = {"paper-a": {}, "paper-b": {}}
+        result = find_paper_matches("completely-different", index)
+        assert result.match_type == MatchType.NOT_FOUND
+        assert result.matches == []
+
+    def test_empty_query(self):
+        result = find_paper_matches("", {"paper": {}})
+        assert result.match_type == MatchType.NOT_FOUND
+
+    def test_empty_index(self):
+        result = find_paper_matches("paper", {})
+        assert result.match_type == MatchType.NOT_FOUND
+
+    def test_cutoff_threshold_high(self):
+        index = {"very-specific-name": {}}
+        # Low similarity should not match with high cutoff
+        result = find_paper_matches("abc", index, fuzzy_cutoff=0.9)
+        assert result.match_type == MatchType.NOT_FOUND
+
+    def test_preserves_original_query(self):
+        index = {"if-net": {}}
+        result = find_paper_matches("  ifnet  ", index)
+        assert result.query == "  ifnet  "
+        assert result.normalized_query == "ifnet"
+
+    def test_normalized_collision_returns_fuzzy(self):
+        """Multiple papers normalizing to same value should be FUZZY, not NORMALIZED"""
+        index = {"IF-Net": {}, "if_net": {}}  # Both normalize to "ifnet"
+        result = find_paper_matches("ifnet", index)
+        assert result.match_type == MatchType.FUZZY
+        assert len(result.matches) == 2
+        assert "IF-Net" in result.matches
+        assert "if_net" in result.matches
+
+
+class TestSelectPaperInteractively:
+    def test_returns_none_for_empty_list(self):
+        result = select_paper_interactively([], "query", {})
+        assert result is None
+
+    def test_single_match_returns_none_non_tty(self, monkeypatch):
+        """Single match should NOT auto-select - requires TTY confirmation"""
+        import sys
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        result = select_paper_interactively(["paper-a"], "query", {})
+        assert result is None
+
+    def test_returns_none_for_non_tty(self, monkeypatch):
+        import sys
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        result = select_paper_interactively(["a", "b"], "query", {})
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "choice,expected",
+        [
+            (1, "paper-a"),
+            (2, "paper-b"),
+            (0, None),
+        ],
+    )
+    def test_interactive_selection(self, monkeypatch, choice, expected):
+        import sys
+
+        import click
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(click, "prompt", lambda *args, **kwargs: choice)
+
+        result = select_paper_interactively(["paper-a", "paper-b"], "query", {})
+        assert result == expected
+
+    def test_handles_abort(self, monkeypatch):
+        import sys
+
+        import click
+
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+        def raise_abort(*args, **kwargs):
+            raise click.Abort()
+
+        monkeypatch.setattr(click, "prompt", raise_abort)
+
+        result = select_paper_interactively(["paper-a", "paper-b"], "query", {})
+        assert result is None
+
+
+class TestGetBestFuzzySimilarity:
+    def test_identical_names(self):
+        assert get_best_fuzzy_similarity("paper", "paper") == 1.0
+
+    def test_normalized_identical(self):
+        assert get_best_fuzzy_similarity("if-net", "ifnet") == 1.0
+
+    def test_different_names(self):
+        sim = get_best_fuzzy_similarity("paper", "completely-different")
+        assert sim < 0.5
+
+    def test_similar_names(self):
+        sim = get_best_fuzzy_similarity("nerf2020", "nerf-2020")
+        assert sim == 1.0  # Normalized forms are identical
+
+
+class TestMatchResult:
+    def test_dataclass_creation(self):
+        result = MatchResult(
+            match_type=MatchType.EXACT,
+            matches=["paper"],
+            query="query",
+            normalized_query="query",
+        )
+        assert result.match_type == MatchType.EXACT
+        assert result.matches == ["paper"]
+
+    def test_match_type_values(self):
+        assert MatchType.EXACT.value == "exact"
+        assert MatchType.NORMALIZED.value == "normalized"
+        assert MatchType.FUZZY.value == "fuzzy"
+        assert MatchType.NOT_FOUND.value == "not_found"


### PR DESCRIPTION
## Summary

Add fuzzy/flexible name matching to paper resolution, allowing users to find papers without remembering exact casing or punctuation.

Closes: #36

## Changes

- **New `paperpipe/matching.py`**: Standalone module with `MatchType` enum, `MatchResult` dataclass, and pure functions for normalization, matching, and interactive selection
- **Modified `paperpipe/core.py`**: Integrate fuzzy matching into `_resolve_paper_name_from_ref()` before arXiv fallback
- **New `tests/test_matching.py`**: 32 unit tests for matching module
- **Extended `tests/test_core.py`**: 6 integration tests for fuzzy resolution

## Behavior

| Input | Output | Match Type |
|-------|--------|------------|
| `papi show mip-nerf` | mip-nerf | exact |
| `papi show mipnerf` | mip-nerf | normalized |
| `papi show NERF` | nerf | normalized |
| `papi show 3dter` | 3detr | fuzzy (auto, ≥0.85) |
| `papi show nerfx` (TTY) | interactive select | fuzzy (multiple) |
| `papi show nerfx` (pipe) | "Did you mean: nerf, nerf-w, d-nerf?" | fuzzy (multiple) |

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Ran `make check` — 374 passed, 77.5% coverage
- [x] Added unit tests for matching module (32 tests)
- [x] Added integration tests for resolver (6 tests)
- [x] Manually verified with real paper database

## Checklist

- [x] Code follows existing style (ruff format/lint pass)
- [x] No new dependencies (stdlib `difflib` only)
- [x] Backward compatible (exact matches unchanged)