### PR TITLE
fix(cli): clarify --rg is literal-match, not regex by default

### DIFF
--- a/paperpipe/cli/search_cli.py
+++ b/paperpipe/cli/search_cli.py
@@ -76,7 +76,7 @@ def _parse_papers_option(_ctx: click.Context, _param: click.Parameter, value: Op
     "--rg",
     "use_grep",
     is_flag=True,
-    help="Use ripgrep/grep for fast exact-match search (shows file:line hits).",
+    help="Use ripgrep/grep for fast literal-match search (shows file:line hits). Add --regex for regex patterns.",
 )
 @click.option(
     "--fixed-strings/--regex",

--- a/skills/papi/SKILL.md
+++ b/skills/papi/SKILL.md
@@ -44,8 +44,8 @@ papi list | grep -i "keyword"  # check if paper exists before searching
 ## Search Commands
 
 ```bash
-papi search --rg "query"              # exact text (fast, no LLM)
-papi search --rg --regex "pattern"    # regex (OR, wildcards)
+papi search --rg "query"              # literal text match (fast, no LLM) — NOT regex by default!
+papi search --rg --regex "pattern"    # regex patterns (add --regex explicitly)
 papi search "query"                   # ranked BM25
 papi search --hybrid "query"          # ranked + exact boost
 papi search "query" -p paper1,paper2  # limit search to specific papers

--- a/skills/papi/commands.md
+++ b/skills/papi/commands.md
@@ -10,8 +10,8 @@
 | `papi tags` | List all tags with counts |
 | `papi search "query"` | Ranked search (BM25 if `search.db` exists) |
 | `papi search "query" -p paper1,paper2` | Search within specific papers |
-| `papi search --rg QUERY` | Exact text via ripgrep |
-| `papi search --rg --regex PATTERN` | Regex patterns |
+| `papi search --rg QUERY` | Literal text match via ripgrep (NOT regex by default) |
+| `papi search --rg --regex PATTERN` | Regex patterns (must add `--regex` explicitly) |
 | `papi show <papers...> [-l eq\|tex\|summary]` | Print paper content |
 | `papi notes <paper> [--print]` | Open/print implementation notes |
 | `papi index [--backend pqa\|leann\|search]` | Build retrieval index |


### PR DESCRIPTION
## Summary

Agents were confused that `papi search --rg` doesn't do regex by default. This PR clarifies the behavior in help text and documentation.

## Changes

- `search_cli.py`: Update `--rg` help to say "literal-match" and mention "Add --regex for regex patterns"
- `skills/papi/SKILL.md`: Add "NOT regex by default!" warning to search examples  
- `skills/papi/commands.md`: Clarify table entries for `--rg` vs `--rg --regex`
- `cli/__init__.py`: Add `AliasGroup` to show aliases inline (`list, ls`) instead of duplicates

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran `make check` — all tests pass
- [x] Verified `papi --help` shows aliases inline
- [x] Verified aliases still work (`papi rm --help`, `papi s --help`)

## Checklist

- [x] Code follows existing style
- [x] Documentation updated